### PR TITLE
Add MPA prerender demo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -112,6 +112,7 @@
 			<li><a href="/stack-navigator/spa/">SPA</a></li>
 			<li><a href="/stack-navigator/navigation-api/">Navigation API</a></li>
 			<li><a href="/stack-navigator/mpa/">MPA</a> <em>(👨‍🔬 Needs <code>#view-transition-on-navigation</code> flag)</em></li>
+			<li><a href="/stack-navigator/mpa-prerender/">MPA (with Prerender)</a> <em>(👨‍🔬 Needs <code>#view-transition-on-navigation</code> flag)</em></li>
 		</ul>
 
 		<footer>

--- a/src/stack-navigator/mpa-prerender/detail.html
+++ b/src/stack-navigator/mpa-prerender/detail.html
@@ -8,6 +8,17 @@
 		<link rel="stylesheet" href="../shared/styles.css">
 		<link rel="stylesheet" href="mpa.css">
 		<script src="scripts.js"></script>
+		<script type="speculationrules">
+			{
+			  "prerender": [{
+				"source": "document",
+				"where": {
+				  "href_matches": "/*"
+				},
+				"eagerness": "moderate"
+			  }]
+			}
+		</script>
 </head>
 <body>
 		<div id="detail" class="view">

--- a/src/stack-navigator/mpa-prerender/detail.html
+++ b/src/stack-navigator/mpa-prerender/detail.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+		<meta charset="UTF-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Messages: Detail 1</title>
+		<link rel="stylesheet" href="../shared/styles.css">
+		<link rel="stylesheet" href="mpa.css">
+		<script src="scripts.js"></script>
+</head>
+<body>
+		<div id="detail" class="view">
+				<h1><a href="./" class="back">&larr;</a> Message</h1>
+				<div class="col">
+						<div class="message">
+								<header>
+										<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+										<div>
+												<div class="author">Bramus</div>
+												<div class="handle">@bramus</div>
+										</div>
+								</header>
+								<div class="content">
+										Aenean suscipit, leo sed malesuada vehicula, ante est consequat neque, vel congue elit nibh quis tellus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut maximus, nunc sit amet semper venenatis, ex urna pulvinar tortor, id scelerisque augue leo sed ligula.
+								</div>
+								<div class="meta">
+										6:49pm - 5 Dec 2023
+								</div>
+								<ul class="rt">
+										<li><b>120</b> remessages</li>
+										<li><b>270</b> likes</li>
+										</i>
+						</div>
+						<ul class="messages">
+								<li>
+										<a href="detail2.html">
+												<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+												<div>
+														<div class="author">Bramus</div>
+														<div class="content">Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
+												</div>
+										</a>
+								</li>
+						</ul>
+				</div>
+		</div>
+</body>
+</html>

--- a/src/stack-navigator/mpa-prerender/detail2.html
+++ b/src/stack-navigator/mpa-prerender/detail2.html
@@ -8,6 +8,17 @@
 		<link rel="stylesheet" href="../shared/styles.css">
 		<link rel="stylesheet" href="mpa.css">
 		<script src="scripts.js"></script>
+		<script type="speculationrules">
+			{
+			  "prerender": [{
+				"source": "document",
+				"where": {
+				  "href_matches": "/*"
+				},
+				"eagerness": "moderate"
+			  }]
+			}
+		</script>
 </head>
 <body>
 		<div id="detail" class="view">

--- a/src/stack-navigator/mpa-prerender/detail2.html
+++ b/src/stack-navigator/mpa-prerender/detail2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+		<meta charset="UTF-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Messages: Detail 2</title>
+		<link rel="stylesheet" href="../shared/styles.css">
+		<link rel="stylesheet" href="mpa.css">
+		<script src="scripts.js"></script>
+</head>
+<body>
+		<div id="detail" class="view">
+				<h1><a href="./" class="back">&larr;</a> Message</h1>
+				<div class="col">
+						<div class="message">
+								<header>
+										<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+										<div>
+												<div class="author">Bramus</div>
+												<div class="handle">@bramus</div>
+										</div>
+								</header>
+								<div class="content">
+										Lorem ipsum dolor sit amet consectetur adipisicing elit.
+								</div>
+								<div class="meta">
+										7:32pm - 6 Dec 2023
+								</div>
+								<ul class="rt">
+										<li><b>12</b> remessages</li>
+										<li><b>20</b> likes</li>
+										</i>
+						</div>
+				</div>
+		</div>
+</body>
+</html>

--- a/src/stack-navigator/mpa-prerender/index.html
+++ b/src/stack-navigator/mpa-prerender/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+		<meta charset="UTF-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Messages: Overview</title>
+		<link rel="stylesheet" href="../shared/styles.css">
+		<link rel="stylesheet" href="mpa.css">
+		<script src="scripts.js"></script>
+		<script type="speculationrules">
+			{
+			  "prerender": [{
+				"source": "document",
+				"where": {
+				  "href_matches": "/*"
+				},
+				"eagerness": "moderate"
+			  }]
+			}
+		</script>
+</head>
+<body>
+		<div id="home" class="view">
+				<h1><a href="./">🏠</a> Home</h1>
+				<div class="col">
+						<ul class="messages">
+								<li>
+									<a href="detail2.html">
+										<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+										<div>
+												<div class="author">Bramus</div>
+												<div class="content">Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
+										</div>
+									</a>
+								</li>
+								<li>
+									<a href="detail.html">
+										<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+										<div>
+												<div class="author">Bramus</div>
+												<div class="content">Integer id lacus orci. Vestibulum egestas commodo sagittis. Nulla placerat neque quis nisl rhoncus congue. Mauris viverra, nibh a commodo venenatis, nisi ipsum lobortis purus, sed placerat sapien tellus vitae dui.</div>
+										</div>
+									</a>
+								</li>
+								<li>
+									<a href="detail.html">
+										<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+										<div>
+												<div class="author">Bramus</div>
+												<div class="content">Sed dapibus fringilla nibh. Donec aliquam libero nec rhoncus vehicula. Integer a magna posuere nisl scelerisque tristique.</div>
+										</div>
+									</a>
+								</li>
+								<li>
+									<a href="detail.html">
+										<img src="../shared/avatar.jpg" alt="Avatar of Bramus" width="100" height="100">
+										<div>
+												<div class="author">Bramus</div>
+												<div class="content">Aenean suscipit, leo sed malesuada vehicula, ante est consequat neque, vel congue elit nibh quis tellus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut maximus, nunc sit amet semper venenatis, ex urna pulvinar tortor, id scelerisque augue leo sed ligula.</div>
+										</div>
+									</a>
+								</li>
+						</ul>
+				</div>
+		</div>
+</body>
+</html>

--- a/src/stack-navigator/mpa-prerender/mpa.css
+++ b/src/stack-navigator/mpa-prerender/mpa.css
@@ -1,0 +1,3 @@
+@view-transition {
+	navigation: auto;
+}

--- a/src/stack-navigator/mpa-prerender/scripts.js
+++ b/src/stack-navigator/mpa-prerender/scripts.js
@@ -1,0 +1,102 @@
+// Path where this app is deployed. Because we don’t deploy at the root of the domain
+// we need to keep track of this and adjust any URL matching using this value.
+const basePath = '/stack-navigator/mpa-prerender';
+
+// Convert all UI back links to a UA back.
+//
+// If there is no previous navigation entry to go to
+// (e.g. user went directly to detail), then redirect to index.html
+document.addEventListener('click', (e) => {
+	if (e.target.matches('a.back')) {
+		e.preventDefault();
+
+		if (navigation.canGoBack) {
+			navigation.back();
+		} else {
+			navigation.navigate(`${basePath}/`);
+		}
+	}
+});
+
+
+// MPA View Transitions!
+window.addEventListener("pagereveal", async (e) => {
+
+	// There is an automatic viewTransition, so the user comes from the same origin
+	if (e.viewTransition) {
+
+		if (!navigation.activation?.from) {
+			e.viewTransition.skipTransition();
+			return;
+		}
+
+		const transitionClass = determineTransitionClass(navigation.activation.from, navigation.currentEntry);
+		document.documentElement.dataset.transition = transitionClass;
+
+		await e.viewTransition.finished;
+		delete document.documentElement.dataset.transition;
+	}
+
+	// User comes from different origin or did a reload
+	else {
+
+		// Do a reload animation
+		if (navigation.activation.navigationType == 'reload') {
+			document.documentElement.dataset.transition = "reload";
+			const t = document.startViewTransition(() => {
+				// NOOP
+			});
+			try {
+				await t.finished;
+				delete document.documentElement.dataset.transition;
+			} catch (e) {
+				console.log(e);
+			}
+			return;
+		}
+
+		// @TODO: manually create a “welcome” viewTransition here?
+	}
+});
+
+
+// Determine the View Transition class to use based on the old and new navigation entries
+// Also take the navigateEvent into account to detect UA back/forward navigations
+const determineTransitionClass = (oldNavigationEntry, newNavigationEntry) => {
+	const currentURL = new URL(oldNavigationEntry.url);
+	const destinationURL = new URL(newNavigationEntry.url);
+
+	const currentPathname = currentURL.pathname.replace(basePath, '').replace("/index.html", "/");
+	const destinationPathname = destinationURL.pathname.replace(basePath, '').replace("/index.html", "/");
+
+	if (currentPathname === destinationPathname) {
+		return "reload";
+	} else if (currentPathname === "/" && destinationPathname.startsWith('/detail')) {
+		return "push";
+	} else if (currentPathname.startsWith('/detail') && destinationPathname === "/") {
+		return "pop";
+	} else if (currentPathname.startsWith('/detail') && destinationPathname.startsWith('/detail')) {
+		if (isUABackButton(oldNavigationEntry, newNavigationEntry)) {
+			return "pop";
+		} else {
+			return "push";
+		}
+	} else {
+		console.warn('Unmatched Route Handling!');
+		console.log({
+			currentPathname,
+			destinationPathname,
+		});
+		return "none";
+	}
+};
+
+// Determine if the UA back button was used to navigate
+const isUABackButton = (oldNavigationEntry, newNavigationEntry) => {
+	return (newNavigationEntry.index < oldNavigationEntry.index);
+};
+
+// Determine if the UA forward button was used to navigate
+const isUAForwardButton = (oldNavigationEntry, newNavigationEntry) => {
+	return (newNavigationEntry.index > oldNavigationEntry.index);
+};


### PR DESCRIPTION
Copies /mpa to /mpa-prerender and adds speculation rules for prerender

These are the rules:
```js
		<script type="speculationrules">
			{
			  "prerender": [{
				"source": "document",
				"where": {
				  "href_matches": "/*"
				},
				"eagerness": "moderate"
			  }]
			}
		</script>
```

This prerenders on links on 200ms hover or mouse/pointer down.

As the list of links is small, we could change `"eagerness": "moderate"` to `"eagerness": "immediate"` so it prerenders all the links it finds on page load so has less of a delay. For production sites though I recommend `moderate` so only prerender when user interacts with the link. WDYT?